### PR TITLE
Add ARM Docker CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  # Repeated pushes to a PR will cancel all previous still running builds of the
+  # PR (for faster feedback), while multiple merges to master will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: bbg-bbb-release-debian11-armv7
+            docker_platform: linux/arm/v7
+            make_vars: BBG_BBB=true BYAI= BBAI_64= BBAI= RPI=
+          - name: bbai64-release-debian11-arm64
+            docker_platform: linux/arm64
+            make_vars: BBAI_64=true BYAI= BBG_BBB= BBAI= RPI=
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        run: |
+          make docker-setup-qemu
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/kiwisdr-ccache
+          key: ccache-${{ runner.os }}-${{ matrix.name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ matrix.name }}-
+            ccache-${{ runner.os }}-
+
+      - name: Build
+        run: |
+          make docker-build \
+            DOCKER_PLATFORM="${{ matrix.docker_platform }}" \
+            DOCKER_MAKE_VARS="${{ matrix.make_vars }}"
+
+      - name: Upload binary distro artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.name }}-binary-distro
+          path: ci-artifacts/
+          if-no-files-found: error
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ci-artifacts/

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ BINARY_DISTRO := true
 
 include Makefile.comp.inc
 
+ifeq ($(KIWI_CCACHE),true)
+    CC := ccache $(CC)
+    CPP := ccache $(CPP)
+endif
+
 # for any config-specific options/dependencies
 -include ../kiwi.config/Makefile.kiwi.inc
 
@@ -2261,3 +2266,46 @@ ifeq ($(DEBIAN_DEVSYS),$(DEBIAN))
 	    blockdev --flushbufs /dev/mmcblk$(SD_CARD_MMC_COPY)
 	    date
 endif
+
+.PHONY: docker-setup-qemu
+docker-setup-qemu:
+	docker run --privileged --rm tonistiigi/binfmt --install all
+
+DOCKER_PLATFORM ?= linux/arm/v7
+DOCKER_MAKE_VARS ?= BBG_BBB=true BYAI= BBAI_64= BBAI= RPI=
+DOCKER_CCACHE_DIR ?= $(HOME)/.cache/kiwisdr-ccache
+
+.PHONY: ci-binary-artifacts
+ci-binary-artifacts: $(BUILD_DIR)/kiwi.bin $(BUILD_DIR)/kiwid.bin
+	mkdir -p ci-artifacts/bin
+	cp $(BUILD_DIR)/kiwi.bin $(PLAT_KIWI_BIN_NEW)
+	cp $(BUILD_DIR)/kiwid.bin $(PLAT_KIWID_BIN_NEW)
+	cp $(PLAT_KIWI_BIN_NEW) $(PLAT_KIWID_BIN_NEW) ci-artifacts/bin/
+	(cd ci-artifacts; sha256sum bin/*.bin > SHA256SUMS)
+
+.PHONY: docker-build
+docker-build:
+	mkdir -p "$(DOCKER_CCACHE_DIR)"
+	docker run \
+		--rm \
+		--platform "$(DOCKER_PLATFORM)" \
+		-v "$$PWD:/root/KiwiSDR" \
+		-v "$(DOCKER_CCACHE_DIR):/root/.ccache" \
+		-w /root/KiwiSDR \
+		debian:11 /bin/bash -ec "\
+			export DEBIAN_FRONTEND=noninteractive; \
+			apt-get update; \
+			apt-get install -y make rsync ccache; \
+			echo 'Debian' > /etc/dogtag; \
+			export CCACHE_DIR=/root/.ccache; \
+			export PATH=/usr/lib/ccache:\$$PATH; \
+			ccache -M 1G; \
+			make check_detect KIWI_CCACHE=true $(DOCKER_MAKE_VARS); \
+			mkdir -p /root/kiwi.config; \
+			make lftp KIWI_CCACHE=true $(DOCKER_MAKE_VARS); \
+			make make_prereq KIWI_CCACHE=true $(DOCKER_MAKE_VARS); \
+			make build_makefile_inc KIWI_CCACHE=true $(DOCKER_MAKE_VARS); \
+			make ci-binary-artifacts KIWI_CCACHE=true $(DOCKER_MAKE_VARS); \
+			make verilog KIWI_CCACHE=true $(DOCKER_MAKE_VARS); \
+			ccache -s \
+		"


### PR DESCRIPTION
Add GitHub Actions workflow for pull requests and master pushes. The workflow builds Debian 11 target binaries in Docker for both supported target classes: ARMv7 BBG/BBB and ARM64 BBAI-64.

Done via:
- Makefile helpers that also work locally on dev machines
- setting up QEMU binfmt support to build binaries for platforms different from the host
- running the target build inside Debian 11 Docker
- enabling ccache for faster repeated builds
- uploading the resulting kiwi/kiwid binaries (available for 7 days for test downloads)

(This potentially needs approval to run the workflow first time via button below in the PR and/or enabling actions at all in the [actions tab](https://github.com/jks-prv/KiwiSDR/actions) ... past workflow runs can be seen in my fork from a test PR https://github.com/dbast/KiwiSDR/actions/runs/27713320849).