### PR TITLE
Update GNSS satellite status for GPS, Galileo, SBAS and QZSS

### DIFF
--- a/gps/sats.cpp
+++ b/gps/sats.cpp
@@ -13,24 +13,24 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program.  If not, see http://www.gnu.org/licenses/
 //
 // http://www.aholme.co.uk/GPS/Main.htm
 //////////////////////////////////////////////////////////////////////////
 
 #include "gps.h"
 
-// NOTE: updated 29-May-2026
+// NOTE: updated 11-Aug-2026
 // Rules enforced:
-// - USABLE => enabled
-// - NOT USABLE / DECOMMISSIONED / RETIRED => commented out (disable) with //
-// - UNDER COMMISSIONING / TEST => commented out (disable) with //
+// - USABLE / OPERATIONAL => enabled
+// - TEST / UNDER COMMISSIONING => enabled if the relevant SIS is actually transmitted
+// - NOT USABLE / DECOMMISSIONED / RETIRED / no confirmed SIS => commented out
 
 SATELLITE Sats[] = {
 
     // SBAS PRN 120-158
     // en.wikipedia.org/wiki/GPS-aided_GEO_augmented_navigation
-    // 29-May-2026 SBAS update based on GPS.gov L1 C/A PRN Code Assignments Jan-2026
+    // 11-Aug-2026 SBAS update based on current provider status and GPS.gov Jan-2026 PRN assignments
     // https://www.gps.gov/sites/default/files/2026-02/L1CA-PRN-code-assignments-2026-Jan_2.pdf
     // PRN, G2 delay, G2 init
     // NB: listed first so better chance of obtaining a channel
@@ -39,17 +39,17 @@ SATELLITE Sats[] = {
     {131, 1012, 00551, SBAS},  // Eutelsat 117 West B
     {133,  603, 01731, SBAS},  // SES-15
     {135,  359, 01216, SBAS},  // Intelsat Galaxy 30
-    {138,  386, 00450, SBAS},  // WAAS GEO 8, 117W - PRN138 reassigned after former Anik F1R retirement; added 29-May-2026 from GPS.gov Jan-2026 assignments (effective through Dec 2029)
+    {138,  386, 00450, SBAS},  // WAAS GEO 8, 117W - PRN138 reassigned in GPS.gov Jan-2026 assignments
 
     // UK-SBAS (United-Kingdom SBAS)
     {158,  904, 01542, SBAS},  // UK SBAS Testbed over Inmarsat 3F5
 
     // EGNOS (Europe SBAS)
-    {121,  175, 01241, SBAS},  // Eutelsat 5WB en.wikipedia.org/wiki/Eutelsat_5_West_B
-    {123,   21, 00232, SBAS},  // ASTRA 5B
-    {126,  886, 01764, SBAS},  // Inmarsat 4F2
-    {136,  595, 00740, SBAS},  // EGNOS SES-5, 5E - comment corrected 29-May-2026 from GPS.gov Jan-2026 assignments
-    {150,  853, 01041, SBAS},  // EGNOS HOTBIRD 13G, 13E - enabled 29-May-2026 from GPS.gov Jan-2026 assignments (effective through May 2031)
+    {121,  175, 01241, SBAS},  // Eutelsat 5WB - ACTIVE Operational Mode MT2
+    {123,   21, 00232, SBAS},  // ASTRA 5B - ACTIVE Test Mode MT0/2
+//  {126,  886, 01764, SBAS},  // Inmarsat 4F2 - not in current EGNOS realtime GEO set
+    {136,  595, 00740, SBAS},  // SES-5, 5E - ACTIVE Operational Mode MT2
+//  {150,  853, 01041, SBAS},  // HOTBIRD 13G, 13E - assigned but not in current EGNOS realtime GEO set
 
     // SDCM (RUSSIA SBAS)
     {125, 235, 01076, SBAS},   // Luch-5B Satellite en.wikipedia.org/wiki/Luch_5B
@@ -64,35 +64,35 @@ SATELLITE Sats[] = {
     {147,  118, 00355, SBAS},  // NigComSat-1R
 
     // GAGAN (India SBAS)
-    {127,  657, 00717, SBAS},  // GSAT-8 en.wikipedia.org/wiki/GSAT-8 
+    {127,  657, 00717, SBAS},  // GSAT-8 en.wikipedia.org/wiki/GSAT-8
     {128,  634, 01532, SBAS},  // GSAT-10 en.wikipedia.org/wiki/GSAT-10
     {132,  176, 00520, SBAS},  // GSAT-15 en.wikipedia.org/wiki/GSAT-15
 
-    // BDSBAS (China SBAS)  en.wikipedia.org/wiki/BeiDou#BeiDou-3
+    // BDSBAS (China SBAS) en.wikipedia.org/wiki/BeiDou#BeiDou-3
     {130,  355, 00341, SBAS},  // Compass-G1
     {143,  307, 01312, SBAS},  // Compass-G3
     {144,  127, 01060, SBAS},  // Compass-G2
 
     // KASS (South Korea SBAS)
     {134,  130, 00706, SBAS},  // MEASAT-3D en.wikipedia.org/wiki/MEASAT_Satellite_Systems
-    {142,  883, 01644, SBAS},  // KASS KOREASAT-116N, 116E - added 29-May-2026 from GPS.gov Jan-2026 assignments (effective through Dec 2027)
+    {142,  883, 01644, SBAS},  // KASS Koreasat-6A, 116E
 
     // MSAS (Japan SBAS)
-    {129,  762, 01250, SBAS},  // MSAS QZS-6, 90.5E - comment corrected 29-May-2026 from GPS.gov Jan-2026 assignments
+    {129,  762, 01250, SBAS},  // MSAS QZS-6, 90.5E - operational
     {137,   68, 01007, SBAS},  // MSAS QZS-3, 127E - operational
-  //{139,  797, 00305, SBAS},  // MSAS QZS-7 - kept disabled 29-May-2026, assigned in GPS.gov Jan-2026 but satellite not launched / not operational
+//  {139,  797, 00305, SBAS},  // MSAS QZS-7 - launched 11-Aug-2026 04:23:31 JST; commissioning/testing, PRN139 SIS not yet confirmed
 
     // SPAN/SouthPAN (AUS/NZ SBAS)
-    {122,   52, 00267, SBAS},  // SPAN/SouthPAN INMARSAT 4F2, 143.5E - comment corrected 29-May-2026 from GPS.gov Jan-2026 assignments
-    {124,  237, 01617, SBAS},  // SPAN/SouthPAN INMARSAT 4F1, 178E - added 29-May-2026 from GPS.gov Jan-2026 assignments (effective through May 2034)
+    {122,   52, 00267, SBAS},  // SPAN/SouthPAN INMARSAT 4F2, 143.5E
+    {124,  237, 01617, SBAS},  // SPAN/SouthPAN INMARSAT 4F1, 178E
 
     // Pak-SBAS (Pakistan SBAS)
-    {145,  211, 01560, SBAS},  // Pak-SBAS PakSat-MM1, 38.2E - added 29-May-2026 from GPS.gov Jan-2026 assignments (effective through May 2027)
+    {145,  211, 01560, SBAS},  // Pak-SBAS PakSat-MM1, 38.2E - TEST SIS retained
 
     // Navstar
     // www.navcen.uscg.gov/gps-constellation
     // PRN, G2 tap, G2 tap
-    
+
     { 1,  2,  6, Navstar},
     { 2,  3,  7, Navstar},
     { 3,  4,  8, Navstar},
@@ -105,7 +105,7 @@ SATELLITE Sats[] = {
     {10,  2,  3, Navstar},
     {11,  3,  4, Navstar},
     {12,  5,  6, Navstar},
-    {13,  6,  7, Navstar},
+//  {13,  6,  7, Navstar},     // SVN43 / PRN13 - DECOMMISSIONED 24-Apr-2026
     {14,  7,  8, Navstar},
     {15,  8,  9, Navstar},
     {16,  9, 10, Navstar},
@@ -127,26 +127,26 @@ SATELLITE Sats[] = {
     {32,  4,  9, Navstar},
 
     // QZSS (Japan) prn(saif) = 183++, prn(std) = 193++
-    // last checked: 29-May-2026
+    // last checked: 11-Aug-2026
     // KiwiSDR typically tracks GPS-like L1 C/A. Keep only QZSS PRNs that transmit L1 C/A.
     // PRN, G2 delay, G2 init
 
-//  {193, 339, 01050, QZSS},   // SVN1, QZS-1, terminated 15-Sep-2023
-    {194, 208, 01607, QZSS},   // SVN2, QZS-2, L1 C/A
-    {195, 711, 01747, QZSS},   // SVN4, QZS-4, L1 C/A
-//  {196, 189, 01305, QZSS},   // SVN5, QZS-1R: L1C/L1C(B) (no L1 C/A) -> disable for L1 C/A-only tracking
-    {199, 663, 00727, QZSS},   // SVN3, QZS-3, L1 C/A
-//  {200, 942, 00147, QZSS},   // SVN7, QZS-6: L1C/L1C(B) (no L1 C/A) -> disable for L1 C/A-only tracking
-//  {201, 173, 01206, QZSS},   // QZS-7: not launched / not operational on L1 C/A
+//  {193, 339, 01050, QZSS},   // SVN1, QZS-1 - terminated 15-Sep-2023
+    {194, 208, 01607, QZSS},   // SVN2, QZS-2 - L1 C/A
+    {195, 711, 01747, QZSS},   // SVN4, QZS-4 - L1 C/A
+//  {196, 189, 01305, QZSS},   // SVN5, QZS-1R - operational but no L1 C/A
+    {199, 663, 00727, QZSS},   // SVN3, QZS-3 - L1 C/A
+//  {200, 942, 00147, QZSS},   // SVN7, QZS-6 - operational but no L1 C/A
+//  {201, 173, 01206, QZSS},   // SVN8, QZS-7 - launched 11-Aug-2026 04:23:31 JST; commissioning/testing, no L1 C/A
 //  {202, 900, 01045, QZSS},   // QZSS Test
 
     // Galileo E1B
-    // last checked: 29-May-2026
-    // Source: GSC Constellation Information (status) + NAGUs 2026033 / 2025061
+    // last checked: 11-Aug-2026
+    // Source: GSC Constellation Information + NAGU 2026041
     // PRN, (E1B codes derived separately)
     // Keep PRNs strictly in numeric order. No blank lines.
 
-  //{ 1,0,0,E1B},    // GSAT0210 (E01) NOT USABLE
+//  { 1,0,0,E1B},    // GSAT0210 (E01) NOT USABLE
     { 2,0,0,E1B},    // GSAT0211 (E02) USABLE
     { 3,0,0,E1B},    // GSAT0212 (E03) USABLE
     { 4,0,0,E1B},    // GSAT0213 (E04) USABLE
@@ -159,29 +159,30 @@ SATELLITE Sats[] = {
     {11,0,0,E1B},    // GSAT0101 (E11) USABLE
     {12,0,0,E1B},    // GSAT0102 (E12) USABLE
     {13,0,0,E1B},    // GSAT0220 (E13) USABLE
-  //{14,0,0,E1B},    // GSAT0202 (E14) NOT USABLE
+//  {14,0,0,E1B},    // GSAT0202 (E14) NOT USABLE
     {15,0,0,E1B},    // GSAT0221 (E15) USABLE
     {16,0,0,E1B},    // GSAT0232 (E16) USABLE
-  //{17,0,0,E1B},    // unused
-  //{18,0,0,E1B},    // GSAT0201 (E18) NOT USABLE
+//  {17,0,0,E1B},    // unused
+//  {18,0,0,E1B},    // GSAT0201 (E18) NOT USABLE
     {19,0,0,E1B},    // GSAT0103 (E19) USABLE
-  //{20,0,0,E1B},    // GSAT0104 (E20) RETIRED/DECOMMISSIONED
+//  {20,0,0,E1B},    // GSAT0104 (E20) RETIRED/DECOMMISSIONED
     {21,0,0,E1B},    // GSAT0215 (E21) USABLE
-  //{22,0,0,E1B},    // GSAT0204 (E22) NOT USABLE
+//  {22,0,0,E1B},    // GSAT0204 (E22) NOT USABLE
     {23,0,0,E1B},    // GSAT0226 (E23) USABLE
-  //{24,0,0,E1B},    // GSAT0205 (E24) DECOMMISSIONED
+//  {24,0,0,E1B},    // GSAT0205 (E24) DECOMMISSIONED
     {25,0,0,E1B},    // GSAT0216 (E25) USABLE
     {26,0,0,E1B},    // GSAT0203 (E26) USABLE
     {27,0,0,E1B},    // GSAT0217 (E27) USABLE
-    {28,0,0,E1B},    // GSAT0233 (E28) PHM - USABLE since 2026-05-21 10:31 UTC - NAGU 2026033 USABINIT
+    {28,0,0,E1B},    // GSAT0233 (E28) PHM - USABLE since 21-May-2026 10:31 UTC
     {29,0,0,E1B},    // GSAT0225 (E29) USABLE
     {30,0,0,E1B},    // GSAT0206 (E30) USABLE
     {31,0,0,E1B},    // GSAT0218 (E31) USABLE
-  //{32,0,0,E1B},    // GSAT0234 (E32) UNDER COMMISSIONING - launched with GSAT0233 on 2025-12-17 05:01 UTC - NAGU 2025061 LAUNCH
+    {32,0,0,E1B},    // GSAT0234 (E32) PHM - USABLE since 23-Jul-2026 14:25 UTC - NAGU 2026041
     {33,0,0,E1B},    // GSAT0222 (E33) USABLE
     {34,0,0,E1B},    // GSAT0223 (E34) USABLE
-  //{35,0,0,E1B},    // unused
+//  {35,0,0,E1B},    // unused
     {36,0,0,E1B},    // GSAT0219 (E36) USABLE
-    
+
     {-1}
+
 };


### PR DESCRIPTION
Update the satellite configuration table to reflect constellation and SBAS status as of 11 August 2026.

Main changes:

* Enable Galileo E32 / GSAT0234, declared USABLE since 23 July 2026.
* Disable GPS PRN13 / SVN43 following its decommissioning on 24 April 2026.
* Update EGNOS GEO status while keeping PRN123 enabled in TEST mode, since its SIS is currently transmitted.
* Keep TEST, demonstration and commissioning SBAS signals enabled when an actual trackable SIS is being broadcast.
* Update QZSS/MSAS entries following the successful launch of QZS-7 on 11 August 2026.
* Keep QZS-7 PRN201 disabled for QZSS tracking because the satellite does not transmit L1 C/A.
* Keep MSAS PRN139 disabled until an actual QZS-7 MSAS L1Sb SIS transmission is confirmed.
* Refresh several satellite comments and provider/status references.
* Keep satellite comments on a single line to preserve the existing source-code formatting and parsing conventions.

The update intentionally distinguishes between operational certification and actual signal availability: TEST or commissioning status alone is not considered a reason to disable a satellite when the relevant Signal-In-Space is being transmitted and can be tracked by the receiver.

Status information was cross-checked against the current constellation information published by the relevant GNSS/SBAS providers, including Galileo GSC, GPS NAVCEN, EGNOS and QZSS sources.

73
Benjamin
F4FPR / K5AW