### PR TITLE
HFDL: reset errno before strtol/strtof in parse_int32/parse_double

### DIFF
--- a/extensions/HFDL/dumphfdl/src/hfdl_main.c
+++ b/extensions/HFDL/dumphfdl/src/hfdl_main.c
@@ -170,6 +170,7 @@ static bool parse_double(char const *str, double *result) {
 	ASSERT(str != NULL);
 	ASSERT(result != NULL);
 	char *endptr = NULL;
+	errno = 0;
 	double val = strtof(str, &endptr);
 	if(endptr == str || endptr[0] != '\0') {
 		fprintf(stderr, "Parameter error: '%s': not a valid floating-point number\n", str);
@@ -186,6 +187,7 @@ static bool parse_int32(char const *str, int32_t *result) {
 	ASSERT(str != NULL);
 	ASSERT(result != NULL);
 	char *endptr = NULL;
+	errno = 0;
 	long val = strtol(str, &endptr, 10);
 	if(endptr == str || endptr[0] != '\0') {
 		fprintf(stderr, "Parameter error: '%s': not a valid decimal integer number\n", str);


### PR DESCRIPTION
The HFDL extension never decodes anything: dumphfdl_main() returns 1 immediately every time HFDL starts, before it reaches ac_cache_create(), input_init(), fft_create() or channel setup.

parse_int32() checks errno == ERANGE right after strtol() to catch overflow, but never resets errno to 0 first. strtol() only sets errno on overflow and never clears it on success, so parse_int32() is really testing whatever some unrelated earlier libc call left behind.

In kiwid's long-running single-threaded event loop, that stale value is essentially random by the time HFDL starts, so a perfectly valid --sample-rate value gets rejected. gdb confirms it: parse_int32("36000") returns false despite 36000 being in range, sending dumphfdl_main() straight to `return 1`.

parse_double(), used for --centerfreq, --gain and --freq-correction, has the same bug; it just hasn't been seen failing yet because parsing never gets that far.

Fix both functions by resetting errno = 0 immediately before the strtol()/strtof() call, as strtol(3) documents.

Assisted-by: Claude:claude-sonnet-5